### PR TITLE
Removing no-unused-variable for tslint 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "dependencies": {
     "tslint-eslint-rules": "^2.0.1"
+  },
+  "peerDependencies": {
+    "tslint": ">=4.0.0"
   }
 }

--- a/test/rules/handle-callback-err.out
+++ b/test/rules/handle-callback-err.out
@@ -1,2 +1,1 @@
-handle-callback-err.ts[1, 10]: Unused function: 'cb'
 handle-callback-err.ts[1, 14]: Expected error to be handled

--- a/test/rules/no-inner-declarations.out
+++ b/test/rules/no-inner-declarations.out
@@ -1,3 +1,2 @@
 no-inner-declarations.ts[4, 20]: block is empty
-no-inner-declarations.ts[4, 12]: Unused function: 'test'
 no-inner-declarations.ts[4, 3]: move function declaration to program root

--- a/test/rules/no-multi-spaces.out
+++ b/test/rules/no-multi-spaces.out
@@ -1,2 +1,1 @@
-no-multi-spaces.ts[1, 7]: Unused variable: 'test'
 no-multi-spaces.ts[1, 15]: Multiple spaces found before 'true'.

--- a/test/rules/semicolon.out
+++ b/test/rules/semicolon.out
@@ -1,2 +1,1 @@
-semicolon.ts[1, 7]: Unused variable: 'foo'
 semicolon.ts[1, 17]: Unnecessary semicolon

--- a/test/rules/trailing-comma.out
+++ b/test/rules/trailing-comma.out
@@ -1,2 +1,1 @@
-trailing-comma.ts[1, 7]: Unused variable: 'foo'
 trailing-comma.ts[3, 7]: Unnecessary trailing comma

--- a/tslint.js
+++ b/tslint.js
@@ -53,7 +53,6 @@ module.exports = {
     'no-switch-case-fall-through': true,
     'no-unreachable': true,
     'no-unused-expression': true,
-    'no-unused-variable': true,
     'no-var-keyword': true,
     'radix': true,
     'triple-equals': [


### PR DESCRIPTION
https://github.com/palantir/tslint/issues/1481

It is deprecated in favor of:
https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#flag-unused-declarations-with---nounusedparameters-and---nounusedlocals

But don't release until https://github.com/Microsoft/vscode-tslint/issues/123 is fixed.