### PR TITLE
use single quote for jsx quotes

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -97,7 +97,8 @@ module.exports = {
     'quotemark': [
       true,
       'single',
-      'avoid-escape'
+      'avoid-escape',
+      'jsx-single'
     ],
     'semicolon': [
       true,


### PR DESCRIPTION
I don't know if it is a new config or not but tslint suddenly changes my jsx quotes to double quotes on fix. This should keep the old behavior