### PR TITLE
Fix typo in whitespace config

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -126,7 +126,7 @@ module.exports = {
       'check-decl',
       'check-operator',
       'check-module',
-      'check-seperator',
+      'check-separator',
       'check-type',
       'check-typecast',
       'check-preblock'


### PR DESCRIPTION
The rule ended up never checking separators

This is probably a semver-major change