### PR TITLE
Remove deprecated no-unused-variable rule

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -34,7 +34,6 @@ module.exports = {
     'no-return-await': true,
     'no-switch-case-fall-through': true,
     'no-unused-expression': [true, 'allow-fast-null-checks', 'allow-tagged-template'],
-    'no-unused-variable': [true, { 'ignore-pattern': '^_' }],
     'no-use-before-declare': true,
     'no-var-keyword': true,
     'radix': true,


### PR DESCRIPTION
`no-unused-variable` was deprecated in tslint 5.11.0

Fixes #49